### PR TITLE
Copy NODE* env vars for cron jobs.

### DIFF
--- a/files/service/with-pgenvblock.pl
+++ b/files/service/with-pgenvblock.pl
@@ -16,7 +16,7 @@ close $fh;
 my @entries = split /\x00/, $content;
 
 for my $entry (@entries) {
-    if ($entry =~ /\A(?<varname>PG[^=]+)=(?<varvalue>.*)\Z/m) {
+    if ($entry =~ /\A(?<varname>(?:PG|NODE)[^=]+)=(?<varvalue>.*)\Z/m) {
         $ENV{$+{varname}} = $+{varvalue};
     }
 }


### PR DESCRIPTION
Central uses [cron jobs](https://github.com/caktus/central/blob/9351f7c940e1b914c4d2e9823ab9e3394a22917b/files/service/crontab#L1-L5) to run periodic tasks (e.g. uploading files to S3, purging soft-deleted forms, etc.). After upgrading to v2026.1.1 with a  DigitalOcean database with `PGSSLMODE=require`, all the cron jobs were raising an error ("self-signed certificate in certificate chain") when connecting to the DB. We were also experiencing this error in the main app when we first upgraded and fixed it by adding a `NODE_EXTRA_CA_CERTS` env var.

The `with-pgenvblock.pl` script copies `PG*` env vars from the main app so that the cron jobs can be able to access the DB (https://github.com/getodk/central/pull/1756). This PR updates the script to also copy `NODE*` env vars.